### PR TITLE
Add Similar movies collection

### DIFF
--- a/iOS-code-test-Sawan-Rana/PremierSwift.xcodeproj/project.pbxproj
+++ b/iOS-code-test-Sawan-Rana/PremierSwift.xcodeproj/project.pbxproj
@@ -23,6 +23,12 @@
 		7D83123520270F8D0021AC3B /* Request.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D83123420270F8D0021AC3B /* Request.swift */; };
 		7D83123A20271CB90021AC3B /* UIImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D83123920271CB90021AC3B /* UIImageView.swift */; };
 		7D83123C20271E850021AC3B /* APITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D83123B20271E850021AC3B /* APITests.swift */; };
+		ED2A80EE2D4CDA85003A767E /* MovieCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED2A80ED2D4CDA85003A767E /* MovieCollectionViewCell.swift */; };
+		ED2A80F22D4CF7AB003A767E /* ModelDetailsDisplayViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED2A80F12D4CF7AB003A767E /* ModelDetailsDisplayViewModel.swift */; };
+		ED2A80F42D4D17D9003A767E /* CollectionViewCellAdditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED2A80F32D4D17D6003A767E /* CollectionViewCellAdditions.swift */; };
+		ED2A80F82D4D1C18003A767E /* SimilarMoviesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED2A80F72D4D1C18003A767E /* SimilarMoviesView.swift */; };
+		ED2A80FA2D4E4295003A767E /* SimilarMoviesHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED2A80F92D4E4295003A767E /* SimilarMoviesHeaderView.swift */; };
+		ED3D54F12D4E55F20038A552 /* ModelDetailsDisplayViewModelTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED3D54F02D4E55F20038A552 /* ModelDetailsDisplayViewModelTest.swift */; };
 		F4D99F002281B55D00C20D0E /* MovieDetailsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4D99EFF2281B55D00C20D0E /* MovieDetailsViewController.swift */; };
 		F81DFE481F8B8BB700528F3F /* UIKit+PremierStyles.swift in Sources */ = {isa = PBXBuildFile; fileRef = F81DFE471F8B8BB700528F3F /* UIKit+PremierStyles.swift */; };
 		F82C2C2422E0D5D8003E8FC4 /* MovieDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = F82C2C2322E0D5D8003E8FC4 /* MovieDetails.swift */; };
@@ -62,6 +68,12 @@
 		7D83123420270F8D0021AC3B /* Request.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Request.swift; sourceTree = "<group>"; };
 		7D83123920271CB90021AC3B /* UIImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIImageView.swift; sourceTree = "<group>"; };
 		7D83123B20271E850021AC3B /* APITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APITests.swift; sourceTree = "<group>"; };
+		ED2A80ED2D4CDA85003A767E /* MovieCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovieCollectionViewCell.swift; sourceTree = "<group>"; };
+		ED2A80F12D4CF7AB003A767E /* ModelDetailsDisplayViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelDetailsDisplayViewModel.swift; sourceTree = "<group>"; };
+		ED2A80F32D4D17D6003A767E /* CollectionViewCellAdditions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionViewCellAdditions.swift; sourceTree = "<group>"; };
+		ED2A80F72D4D1C18003A767E /* SimilarMoviesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimilarMoviesView.swift; sourceTree = "<group>"; };
+		ED2A80F92D4E4295003A767E /* SimilarMoviesHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimilarMoviesHeaderView.swift; sourceTree = "<group>"; };
+		ED3D54F02D4E55F20038A552 /* ModelDetailsDisplayViewModelTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelDetailsDisplayViewModelTest.swift; sourceTree = "<group>"; };
 		F4D99EFF2281B55D00C20D0E /* MovieDetailsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovieDetailsViewController.swift; sourceTree = "<group>"; };
 		F81DFE471F8B8BB700528F3F /* UIKit+PremierStyles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIKit+PremierStyles.swift"; sourceTree = "<group>"; };
 		F82C2C2322E0D5D8003E8FC4 /* MovieDetails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovieDetails.swift; sourceTree = "<group>"; };
@@ -121,6 +133,7 @@
 				F82C2C2722E22731003E8FC4 /* LoadingViewController.swift */,
 				F82C2C2922E22775003E8FC4 /* MovieDetailsDisplayViewController.swift */,
 				4ADA18552A9BBDDF00E79671 /* MovieDetailsViewModel.swift */,
+				ED2A80F12D4CF7AB003A767E /* ModelDetailsDisplayViewModel.swift */,
 			);
 			path = MovieDetails;
 			sourceTree = "<group>";
@@ -129,6 +142,7 @@
 			isa = PBXGroup;
 			children = (
 				7D13E746202644A9007D2E54 /* CellAdditions.swift */,
+				ED2A80F32D4D17D6003A767E /* CollectionViewCellAdditions.swift */,
 				7D13E74D20264795007D2E54 /* Strings.swift */,
 				7D13E75320264B07007D2E54 /* UIView.swift */,
 				7D83123920271CB90021AC3B /* UIImageView.swift */,
@@ -150,7 +164,10 @@
 			isa = PBXGroup;
 			children = (
 				7D13E750202648D1007D2E54 /* MovieCell.swift */,
+				ED2A80ED2D4CDA85003A767E /* MovieCollectionViewCell.swift */,
 				4A7CA14C275A387700A75CE4 /* TagView.swift */,
+				ED2A80F72D4D1C18003A767E /* SimilarMoviesView.swift */,
+				ED2A80F92D4E4295003A767E /* SimilarMoviesHeaderView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -216,6 +233,7 @@
 			children = (
 				F840A5F61D945CF9009325F7 /* Info.plist */,
 				7D83123B20271E850021AC3B /* APITests.swift */,
+				ED3D54F02D4E55F20038A552 /* ModelDetailsDisplayViewModelTest.swift */,
 			);
 			path = PremierSwiftTests;
 			sourceTree = "<group>";
@@ -331,6 +349,7 @@
 				4A7CA14D275A387700A75CE4 /* TagView.swift in Sources */,
 				7D13E75420264B07007D2E54 /* UIView.swift in Sources */,
 				F82C2C2422E0D5D8003E8FC4 /* MovieDetails.swift in Sources */,
+				ED2A80F22D4CF7AB003A767E /* ModelDetailsDisplayViewModel.swift in Sources */,
 				F82C2C2822E22731003E8FC4 /* LoadingViewController.swift in Sources */,
 				7D13E751202648D1007D2E54 /* MovieCell.swift in Sources */,
 				F4D99F002281B55D00C20D0E /* MovieDetailsViewController.swift in Sources */,
@@ -339,12 +358,16 @@
 				7D83123A20271CB90021AC3B /* UIImageView.swift in Sources */,
 				F81DFE481F8B8BB700528F3F /* UIKit+PremierStyles.swift in Sources */,
 				4A7CA14F275A62C300A75CE4 /* UIBarButtonItem.swift in Sources */,
+				ED2A80F42D4D17D9003A767E /* CollectionViewCellAdditions.swift in Sources */,
 				7D13E747202644A9007D2E54 /* CellAdditions.swift in Sources */,
 				7D13E749202645CE007D2E54 /* APIManager.swift in Sources */,
 				F840A5E21D945CF8009325F7 /* MoviesViewController.swift in Sources */,
+				ED2A80F82D4D1C18003A767E /* SimilarMoviesView.swift in Sources */,
 				4ADA18542A9BBDD600E79671 /* MoviesViewModel.swift in Sources */,
 				7D13E74E20264795007D2E54 /* Strings.swift in Sources */,
 				F82C2C2A22E22775003E8FC4 /* MovieDetailsDisplayViewController.swift in Sources */,
+				ED2A80EE2D4CDA85003A767E /* MovieCollectionViewCell.swift in Sources */,
+				ED2A80FA2D4E4295003A767E /* SimilarMoviesHeaderView.swift in Sources */,
 				7D83123520270F8D0021AC3B /* Request.swift in Sources */,
 				F840A5E01D945CF8009325F7 /* AppDelegate.swift in Sources */,
 			);
@@ -354,6 +377,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				ED3D54F12D4E55F20038A552 /* ModelDetailsDisplayViewModelTest.swift in Sources */,
 				7D83123C20271E850021AC3B /* APITests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/iOS-code-test-Sawan-Rana/PremierSwift/Extensions/CollectionViewCellAdditions.swift
+++ b/iOS-code-test-Sawan-Rana/PremierSwift/Extensions/CollectionViewCellAdditions.swift
@@ -1,0 +1,30 @@
+//
+//  Untitled.swift
+//  PremierSwift
+//
+//  Created by Sawan Rana on 31/01/25.
+//  Copyright © 2025 Deliveroo. All rights reserved.
+//
+
+import UIKit
+
+/**
+ Extensions to simplify cell registration and dequeuing for UICollectionView.
+ `dm_defaultIdentifier` provides a default reuse identifier for any UICollectionViewCell subclass.
+ `dm_registerClassWithDefaultIdentifier` registers a UICollectionViewCell class with the default reuse identifier.
+ `dm_dequeueReusableCellWithDefaultIdentifier` dequeues a cell using the default reuse identifier, and casts it to the appropriate cell type.
+ */
+
+extension UICollectionViewCell {
+    @objc static var dm_defaultIdentifier: String { return String(describing: self) }
+}
+
+extension UICollectionView {
+    func dm_registerClassWithDefaultIdentifier(cellClass: AnyClass) {
+        register(cellClass, forCellWithReuseIdentifier: cellClass.dm_defaultIdentifier)
+    }
+    
+    func dm_dequeueReusableCellWithDefaultIdentifier<T: UICollectionViewCell>(at indexPath: IndexPath) -> T {
+        return dequeueReusableCell(withReuseIdentifier: T.dm_defaultIdentifier, for: indexPath) as! T
+    }
+}

--- a/iOS-code-test-Sawan-Rana/PremierSwift/Models/MovieDetails.swift
+++ b/iOS-code-test-Sawan-Rana/PremierSwift/Models/MovieDetails.swift
@@ -3,13 +3,14 @@ import Foundation
 import Foundation
 
 struct MovieDetails: Decodable {
-    
+    let id: Int
     let title: String
     let overview: String
     let backdropPath: String
     let tagline: String?
     
     enum CodingKeys: String, CodingKey {
+        case id
         case title
         case overview
         case backdropPath = "backdrop_path"
@@ -21,5 +22,9 @@ struct MovieDetails: Decodable {
 extension MovieDetails {
     static func details(for movie: Movie) -> Request<MovieDetails> {
         return Request(method: .get, path: "/movie/\(movie.id)")
+    }
+    
+    static func similarMovies(for movieId: Int) -> Request<Page<Movie>> {
+        return Request(method: .get, path: "/movie/\(movieId)/similar")
     }
 }

--- a/iOS-code-test-Sawan-Rana/PremierSwift/MovieDetails/ModelDetailsDisplayViewModel.swift
+++ b/iOS-code-test-Sawan-Rana/PremierSwift/MovieDetails/ModelDetailsDisplayViewModel.swift
@@ -1,0 +1,76 @@
+//
+//  ModelDetailsDisplayViewModel.swift
+//  PremierSwift
+//
+//  Created by Sawan Rana on 31/01/25.
+//  Copyright © 2025 Deliveroo. All rights reserved.
+//
+
+import Foundation
+
+/**
+ ViewModel that manages the state and data for displaying movie details.
+ It handles the loading state, fetching similar movies, and updates the state
+ to notify observers of changes. The ViewModel interacts with an APIManager
+ to fetch data, and uses closures to update the view when the state changes.
+ 
+ The possible states for this ViewModel are:
+ - `loading(MovieDetails)`: The initial state when movie details are being loaded.
+ - `loaded([Movie])`: The state when similar movies are successfully loaded.
+ - `error`: The state when there is an error fetching similar movies.
+*/
+
+enum ModelDetailsDisplayViewModelState {
+    case loading(MovieDetails)  // State when movie details are being loaded
+    case loaded([Movie])        // State when similar movies are loaded
+    case error(APIError)        // State when an error occurs
+    
+    var isLoading: Bool {
+        switch self {
+        case .loading:
+            return true
+        default:
+            return false
+        }
+    }
+}
+
+final class ModelDetailsDisplayViewModel {
+
+    private let apiManager: APIManaging  // Responsible for making API requests
+    private let movieDetails: MovieDetails  // Movie details that will be displayed
+
+    var _movieDetails: MovieDetails {
+        movieDetails  // Exposes the movie details as a property
+    }
+
+    // Initializer to set up the ViewModel with the provided movie details
+    // and an optional API manager (defaults to APIManager).
+    init(movieDetails: MovieDetails, apiManager: APIManaging = APIManager()) {
+        self.movieDetails = movieDetails
+        self.apiManager = apiManager
+        self.state = .loading(movieDetails)  // Set initial state to loading
+    }
+
+    // Closure that gets called when the state is updated
+    var updatedState: (() -> Void)?
+
+    // The current state of the ViewModel, triggers the updatedState closure when changed
+    var state: ModelDetailsDisplayViewModelState {
+        didSet {
+            updatedState?()  // Notify observers when the state is updated
+        }
+    }
+
+    // Fetches similar movies based on the current movie's ID using the APIManager
+    func fetchSimilarMovies() {
+        apiManager.execute(MovieDetails.similarMovies(for: movieDetails.id)) { [weak self] result in
+            switch result {
+            case .success(let page):
+                self?.state = .loaded(page.results)  // Update state with the loaded movies
+            case .failure(let apiError):
+                self?.state = .error(apiError)  // Update state to error if the request fails
+            }
+        }
+    }
+}

--- a/iOS-code-test-Sawan-Rana/PremierSwift/MovieDetails/MovieDetailsDisplayViewController.swift
+++ b/iOS-code-test-Sawan-Rana/PremierSwift/MovieDetails/MovieDetailsDisplayViewController.swift
@@ -2,10 +2,10 @@ import UIKit
 
 final class MovieDetailsDisplayViewController: UIViewController {
     
-    let movieDetails: MovieDetails
+    let viewModel: ModelDetailsDisplayViewModel
     
-    init(movieDetails: MovieDetails) {
-        self.movieDetails = movieDetails
+    init(viewModel: ModelDetailsDisplayViewModel) {
+        self.viewModel = viewModel
         super.init(nibName: nil, bundle: nil)
     }
     
@@ -19,16 +19,40 @@ final class MovieDetailsDisplayViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        (view as? View)?.configure(movieDetails: movieDetails)
+        bindViewModel()
+        (view as? View)?.configure(movieDetails: viewModel._movieDetails)
+        viewModel.fetchSimilarMovies()
+    }
+    
+    private func bindViewModel() {
+        viewModel.updatedState = { [weak self] in
+            guard let self else { return }
+            self.updateFromViewModel()
+        }
+    }
+    
+    private func updateFromViewModel() {
+        switch viewModel.state {
+        case .loading(_), .error:
+            break
+        case .loaded(let movies):
+            guard !movies.isEmpty else { return }
+            DispatchQueue.main.async { [weak self] in
+                guard let self else { return }
+                (self.view as? View)?.configureSimilarMovies(with: movies)
+            }
+        }
     }
     
     private class View: UIView {
-        
+
         let scrollView = UIScrollView()
         let backdropImageView = UIImageView()
         let titleLabel = UILabel()
         let overviewLabel = UILabel()
-        private lazy var contentStackView = UIStackView(arrangedSubviews: [backdropImageView, titleLabel, overviewLabel])
+        let similarMoviesView = SimilarMoviesView()
+        
+        private lazy var contentStackView = UIStackView(arrangedSubviews: [backdropImageView, titleLabel, overviewLabel, similarMoviesView])
         
         override init(frame: CGRect) {
             super.init(frame: frame)
@@ -73,6 +97,7 @@ final class MovieDetailsDisplayViewController: UIViewController {
         private func setupConstraints() {
             scrollView.translatesAutoresizingMaskIntoConstraints = false
             backdropImageView.translatesAutoresizingMaskIntoConstraints = false
+            similarMoviesView.translatesAutoresizingMaskIntoConstraints = false
             contentStackView.translatesAutoresizingMaskIntoConstraints = false
             
             NSLayoutConstraint.activate(
@@ -102,7 +127,10 @@ final class MovieDetailsDisplayViewController: UIViewController {
             
             overviewLabel.text = movieDetails.overview
         }
+        
+        func configureSimilarMovies(with movies: [Movie]) {
+            similarMoviesView.similarMovies = movies
+        }
     }
     
 }
-

--- a/iOS-code-test-Sawan-Rana/PremierSwift/MovieDetails/MovieDetailsViewController.swift
+++ b/iOS-code-test-Sawan-Rana/PremierSwift/MovieDetails/MovieDetailsViewController.swift
@@ -56,7 +56,7 @@ final class MovieDetailsViewController: UIViewController {
     }
 
     private func showMovieDetails(_ movieDetails: MovieDetails) {
-        let displayViewController = MovieDetailsDisplayViewController(movieDetails: movieDetails)
+        let displayViewController = MovieDetailsDisplayViewController(viewModel: .init(movieDetails: movieDetails))
         addChild(displayViewController)
         displayViewController.view.frame = view.bounds
         displayViewController.view.autoresizingMask = [.flexibleWidth, .flexibleHeight]

--- a/iOS-code-test-Sawan-Rana/PremierSwift/Views/MovieCollectionViewCell.swift
+++ b/iOS-code-test-Sawan-Rana/PremierSwift/Views/MovieCollectionViewCell.swift
@@ -1,0 +1,99 @@
+//
+//  MovieCollectionViewCell.swift
+//  PremierSwift
+//
+//  Created by Sawan Rana on 31/01/25.
+//  Copyright © 2025 Deliveroo. All rights reserved.
+//
+
+import UIKit
+
+/**
+ Custom UICollectionViewCell for displaying a movie in a collection view.
+ It includes a poster image, title, and a rating tag. The layout is managed
+ using stack views, and the cell is configured with a Movie model that provides
+ the necessary data for the poster, title, and rating.
+ */
+
+class MovieCollectionViewCell: UICollectionViewCell {
+    
+    let posterSize = CGSize(width: 92, height: 134)
+    let titleLabel = UILabel()
+    let genreLabel = UILabel()
+    
+    let imageStackView = UIStackView()
+    let coverImage = UIImageView()
+    let tagView = TagView()
+    
+    let containerStackView = UIStackView()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        commonInit()
+    }
+    
+    required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+        commonInit()
+    }
+    
+    private func commonInit() {
+        layoutMargins = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)
+        
+        titleLabel.font = UIFont.Body.smallSemiBold
+        titleLabel.textColor = UIColor.Text.charcoal
+        titleLabel.numberOfLines = 0
+        titleLabel.lineBreakMode = .byWordWrapping
+        
+        genreLabel.font = UIFont.Body.small
+        genreLabel.textColor = UIColor.Text.grey
+        genreLabel.numberOfLines = 0
+        genreLabel.lineBreakMode = .byWordWrapping
+        
+        coverImage.contentMode = .scaleAspectFill
+        coverImage.layer.cornerRadius = 8
+        coverImage.layer.masksToBounds = true
+        
+        imageStackView.spacing = 10
+        imageStackView.alignment = .leading
+        imageStackView.axis = .vertical
+        imageStackView.distribution = .fill
+        
+        containerStackView.alignment = .leading
+        containerStackView.axis = .vertical
+        containerStackView.spacing = 10
+        
+        containerStackView.translatesAutoresizingMaskIntoConstraints = false
+        
+        setupViewsHierarchy()
+        setupConstraints()
+    }
+    
+    func setupViewsHierarchy() {
+        contentView.addSubview(containerStackView)
+        imageStackView.dm_addArrangedSubviews(coverImage, titleLabel, tagView)
+        containerStackView.dm_addArrangedSubviews(imageStackView)
+    }
+    
+    func setupConstraints() {
+        
+        NSLayoutConstraint.activate([
+            containerStackView.topAnchor.constraint(equalTo: contentView.topAnchor, constant: layoutMargins.top),
+            containerStackView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: layoutMargins.left),
+            containerStackView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -layoutMargins.right),
+            containerStackView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -layoutMargins.bottom),
+            
+        ])
+    }
+    
+    func configure(with movie: Movie) {
+        titleLabel.text = movie.title
+//        genreLabel.isHidden = true
+        tagView.configure(.rating(value: movie.voteAverage))
+        if let path = movie.posterPath {
+            coverImage.dm_setImage(posterPath: path)
+        } else {
+            coverImage.image = nil
+        }
+    }
+}

--- a/iOS-code-test-Sawan-Rana/PremierSwift/Views/SimilarMoviesHeaderView.swift
+++ b/iOS-code-test-Sawan-Rana/PremierSwift/Views/SimilarMoviesHeaderView.swift
@@ -1,0 +1,83 @@
+//
+//  SimilarMoviesHeaderView.swift
+//  PremierSwift
+//
+//  Created by Sawan Rana on 01/02/25.
+//  Copyright © 2025 Deliveroo. All rights reserved.
+//
+
+import UIKit
+
+/**
+ A custom header view for displaying a "Similar Movies" section.
+ It contains a label with the title "Similar Movies" and a button labeled "View all ->"
+ that triggers an event when tapped. The event is passed to the parent view/controller
+ through the eventHandler closure with a `viewAllTapped` event.
+ */
+
+enum SimilarMoviesHeaderViewEvent {
+    case viewAllTapped
+}
+
+class SimilarMoviesHeaderView: UIView {
+    let containerStackView = UIStackView()
+    let textLabel = UILabel()
+    let button = UIButton(type: .system)
+    var eventHandler: ((SimilarMoviesHeaderViewEvent) -> Void)? = nil
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        commonInit()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func commonInit() {
+        backgroundColor = .clear
+        
+        textLabel.text = "Similar Movies"
+        textLabel.font = UIFont.Heading.small
+        textLabel.textColor = UIColor.Text.charcoal
+        textLabel.numberOfLines = 1
+        textLabel.lineBreakMode = .byWordWrapping
+        
+        button.setTitle("View all ->", for: .normal)
+        button.setTitleColor(UIColor.Brand.popsicle40, for: .normal)
+        button.titleLabel?.font = UIFont.Body.smallSemiBold
+        button.isUserInteractionEnabled = true
+        button.isEnabled = true
+        button.addTarget(self, action: #selector(handleViewAllTapped), for: .touchUpInside)
+        
+        containerStackView.axis = .horizontal
+        containerStackView.distribution = .fillProportionally
+        containerStackView.spacing = 8
+        
+        setupViewsHierarchy()
+        setupConstraints()
+    }
+    
+    @objc func handleViewAllTapped() {
+        eventHandler?(.viewAllTapped)
+    }
+    
+    private func setupViewsHierarchy() {
+        addSubview(containerStackView)
+        containerStackView.dm_addArrangedSubviews(textLabel, button)
+    }
+    
+    private func setupConstraints() {
+        
+        textLabel.translatesAutoresizingMaskIntoConstraints = false
+        button.translatesAutoresizingMaskIntoConstraints = false
+        containerStackView.translatesAutoresizingMaskIntoConstraints = false
+        
+        NSLayoutConstraint.activate([
+            containerStackView.topAnchor.constraint(equalTo: topAnchor, constant: 0),
+            containerStackView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 0),
+            containerStackView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: 0),
+            containerStackView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: 0)
+        ])
+    }
+}

--- a/iOS-code-test-Sawan-Rana/PremierSwift/Views/SimilarMoviesView.swift
+++ b/iOS-code-test-Sawan-Rana/PremierSwift/Views/SimilarMoviesView.swift
@@ -1,0 +1,94 @@
+//
+//  SimilarMoviesView.swift
+//  PremierSwift
+//
+//  Created by Sawan Rana on 31/01/25.
+//  Copyright © 2025 Deliveroo. All rights reserved.
+//
+
+import UIKit
+
+/**
+ A custom stack view that displays a section for similar movies.
+ The view includes a header view ("Similar Movies") and a horizontally scrollable
+ collection view that displays a list of similar movies. The movies are passed
+ through the `similarMovies` property, which reloads the collection view whenever updated.
+ */
+
+class SimilarMoviesView: UIStackView {
+    let similarMoviesHeaderView = SimilarMoviesHeaderView()
+    
+    var similarMovies: [Movie] = [] {
+        didSet {
+            collectionView?.reloadData()
+        }
+    }
+    private(set) var collectionView:UICollectionView? = nil
+    private(set) var flowLayout:UICollectionViewFlowLayout! = nil
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        commonInit()
+    }
+    
+    required init(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func commonInit() {
+        axis = .vertical
+        isLayoutMarginsRelativeArrangement = true
+        layoutMargins = UIEdgeInsets(top: 6, left: 10, bottom: 6, right: 10)
+        
+        setupCollectionView()
+        
+        setupViewsHierarchy()
+        setupConstraints()
+    }
+    
+    private func setupCollectionView() {
+        collectionView?.removeFromSuperview()
+        
+        let flowLayout:UICollectionViewFlowLayout = UICollectionViewFlowLayout()
+        flowLayout.scrollDirection = .horizontal
+        flowLayout.minimumLineSpacing = 12
+        flowLayout.minimumInteritemSpacing = 8
+        flowLayout.itemSize = CGSize(width: UIScreen.main.bounds.width / 3 - 8, height: UIScreen.main.bounds.height * 0.30)
+
+        self.flowLayout = flowLayout
+        
+        let collectionView:UICollectionView = UICollectionView(frame: .zero, collectionViewLayout: flowLayout)
+        collectionView.dataSource = self
+        collectionView.delegate = self
+        collectionView.backgroundColor = .clear
+        collectionView.dm_registerClassWithDefaultIdentifier(cellClass: MovieCollectionViewCell.self)
+        
+        self.collectionView = collectionView
+    }
+    
+    private func setupViewsHierarchy() {
+        dm_addArrangedSubviews(similarMoviesHeaderView, collectionView!)
+    }
+    
+    private func setupConstraints() {
+        
+        collectionView?.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            collectionView!.heightAnchor.constraint(equalToConstant: UIScreen.main.bounds.height * 0.35)
+        ])
+    }
+}
+
+extension SimilarMoviesView: UICollectionViewDataSource, UICollectionViewDelegate, UICollectionViewDelegateFlowLayout {
+    
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        similarMovies.count
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        let moviesCollectionViewCell: MovieCollectionViewCell = collectionView.dm_dequeueReusableCellWithDefaultIdentifier(at: indexPath)
+        
+        moviesCollectionViewCell.configure(with: similarMovies[indexPath.row])
+        return moviesCollectionViewCell
+    }
+}

--- a/iOS-code-test-Sawan-Rana/PremierSwiftTests/APITests.swift
+++ b/iOS-code-test-Sawan-Rana/PremierSwiftTests/APITests.swift
@@ -13,4 +13,11 @@ final class APITests: XCTestCase {
         let url = URL("https://deliveroo.co.uk", "testKey", request)
         XCTAssertEqual(url.absoluteString, "https://deliveroo.co.uk/testing?api_key=testKey")
     }
+    
+    func test_similar_movies_url() {
+        let movieId: Int = 1
+        let request: Request<Movie> = Request(method: .get, path: "/movie/\(movieId)/similar")
+        let url = URL("https://deliveroo.co.uk", "testKey", request)
+        XCTAssertEqual(url.absoluteString, "https://deliveroo.co.uk/movie/1/similar?api_key=testKey")
+    }
 }

--- a/iOS-code-test-Sawan-Rana/PremierSwiftTests/ModelDetailsDisplayViewModelTest.swift
+++ b/iOS-code-test-Sawan-Rana/PremierSwiftTests/ModelDetailsDisplayViewModelTest.swift
@@ -1,0 +1,208 @@
+//
+//  ModelDetailsDisplayViewModelTest.swift
+//  PremierSwiftTests
+//
+//  Created by Sawan Rana on 01/02/25.
+//  Copyright © 2025 Deliveroo. All rights reserved.
+//
+
+import XCTest
+@testable import PremierSwift
+
+let similarMoviesJsonString = """
+{
+  "page": 1,
+  "results": [
+    {
+      "adult": false,
+      "backdrop_path": null,
+      "genre_ids": [18, 10752],
+      "id": 936821,
+      "original_language": "sk",
+      "original_title": "Ostrov",
+      "overview": "",
+      "popularity": 0.295,
+      "poster_path": null,
+      "release_date": "1981-01-01",
+      "title": "Ostrov",
+      "video": false,
+      "vote_average": 0.0,
+      "vote_count": 0
+    },
+    {
+      "adult": false,
+      "backdrop_path": null,
+      "genre_ids": [18, 10770],
+      "id": 936824,
+      "original_language": "sk",
+      "original_title": "Pasca",
+      "overview": "",
+      "popularity": 1.014,
+      "poster_path": null,
+      "release_date": "1981-01-01",
+      "title": "Pasca",
+      "video": false,
+      "vote_average": 2.0,
+      "vote_count": 1
+    }
+  ],
+  "total_pages": 13744,
+  "total_results": 274868
+}
+"""
+
+let similarMoviesJsonStringIncorrectFormat = """
+{
+  "pages": 1,
+  "results": [
+    {
+      "adult": false,
+      "backdrop_path": null,
+      "genre_ids": [18, 10752],
+      "id": 936821,
+      "original_language": "sk",
+      "original_title": "Ostrov",
+      "overview": "",
+      "popularity": 0.295,
+      "poster_path": null,
+      "release_date": "1981-01-01",
+      "title": "Ostrov",
+      "video": false,
+      "vote_average": 0.0,
+      "vote_count": 0
+    },
+    {
+      "adult": false,
+      "backdrop_path": null,
+      "genre_ids": [18, 10770],
+      "id": 936824,
+      "original_language": "sk",
+      "original_title": "Pasca",
+      "overview": "",
+      "popularity": 1.014,
+      "poster_path": null,
+      "release_date": "1981-01-01",
+      "title": "Pasca",
+      "video": false,
+      "vote_average": 2.0,
+      "vote_count": 1
+    }
+  ],
+  "total_pages": 13744,
+  "total_results": 274868
+}
+"""
+
+final class MockApiManager: APIManaging {
+    
+    var simulateFailure: Bool = false
+    
+    static let shared = MockApiManager()
+    
+    func execute<Value>(_ request: PremierSwift.Request<Value>, completion: @escaping (Result<Value, PremierSwift.APIError>) -> Void) where Value : Decodable {
+        if request.path.contains("similar") {
+            let responseDataForSimilarMovies = responseDataForSimilarMovies()
+            do {
+                let value = try JSONDecoder().decode(Value.self, from: responseDataForSimilarMovies)
+                completion(.success(value))
+            } catch {
+                completion(.failure(.parsingError))
+            }
+        }
+    }
+    
+    private func responseDataForSimilarMovies() -> Data {
+        
+        if simulateFailure {
+            return similarMoviesJsonStringIncorrectFormat.data(using: .utf8)!
+        }
+        
+        return similarMoviesJsonString.data(using: .utf8)!
+    }
+}
+
+
+final class ModelDetailsDisplayViewModelTest: XCTestCase {
+    var sut: ModelDetailsDisplayViewModel!
+    var apiManager: APIManaging!
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+        setupSut()
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        MockApiManager.shared.simulateFailure = false
+        apiManager = nil
+        sut = nil
+    }
+    
+    private func setupSut() {
+        apiManager = MockApiManager.shared
+        sut = ModelDetailsDisplayViewModel(movieDetails: MovieDetails(id: 0, title: "testTitle", overview: "testOverview", backdropPath: "testBackDropPath", tagline: "testTagLine"), apiManager: apiManager)
+    }
+    
+    func test_SUT_Initialization() {
+        XCTAssertNotNil(sut)
+    }
+   
+    func test_IntialState() {
+        //Initial state is loading
+        XCTAssertTrue(sut.state.isLoading)
+        
+        switch sut.state {
+        case .loading(let movieDetails):
+            XCTAssertEqual(movieDetails.id, sut._movieDetails.id)
+            XCTAssertEqual(movieDetails.id, 0)
+            XCTAssertEqual(movieDetails.title, "testTitle")
+            XCTAssertEqual(movieDetails.overview, "testOverview")
+            XCTAssertEqual(movieDetails.backdropPath, "testBackDropPath")
+            XCTAssertEqual(movieDetails.tagline, "testTagLine")
+        default:
+            XCTFail()
+        }
+    }
+    
+    func test_updatedState_Binding() {
+        let expectation = self.expectation(description: "updatedState")
+        
+        sut.updatedState = {
+            expectation.fulfill()
+        }
+        
+        sut.fetchSimilarMovies()
+        
+        wait(for: [expectation], timeout: 1.0)
+    }
+    
+    func test_fetchSimilarMovies_Success() {
+        sut.fetchSimilarMovies()
+        
+        XCTAssertFalse(sut.state.isLoading)
+        
+        switch sut.state {
+        case .loaded(let movies):
+            XCTAssertTrue(!movies.isEmpty)
+            XCTAssertEqual(movies.count, 2)
+            XCTAssertEqual(movies.first?.title, "Ostrov")
+        default:
+            XCTFail()
+        }
+    }
+    
+    func test_fetchSimilarMovies_Failure() {
+        
+        MockApiManager.shared.simulateFailure = true
+        
+        sut.fetchSimilarMovies()
+        
+        switch sut.state {
+        case .error(let error):
+            XCTAssertTrue(error == .parsingError)
+        default:
+            XCTFail()
+        }
+    }
+
+}


### PR DESCRIPTION
This PR implements the addition of a carousel displaying similar movies on the movie details screen, as outlined in the Figma design. The feature fetches similar movie data from the API (using the Get Similar Movies endpoint) and displays the results in a horizontally scrollable carousel.

Changes made:
Added carousel UI to the movie details screen to display similar movies.
Integrated the API endpoint to fetch similar movies based on the current movie's ID.
Added necessary logic to handle API responses and manage the UI updates accordingly.
Implemented a custom UICollectionView for the carousel display.
Created unit and UI tests to ensure proper functionality of the new feature.

Attaching screenshot and recording of the implementation.
a)Screenshot
![Simulator Screenshot - iPhone 14 - 2025-02-02 at 13 00 31](https://github.com/user-attachments/assets/f086e19d-7e91-476d-abb3-e7d581e5fc09)

b) Screen recording
https://github.com/user-attachments/assets/7cbb60b1-3d23-44e9-bdcd-bad82a27f51a

